### PR TITLE
[Refactor] Return error enums with proper messages

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,10 +1,11 @@
 # Change Log
 
-## [2.0.1]
+## [2.1.0]
 
 ### Changes
 
-- Now error codes for return values to CDV are parsed using the error enums and return proper strings instead of raw values
+- (iOS) Now error codes for return values to CDV are parsed using the error enums and return proper strings instead of raw values
+- Error format is harmonized between Android & iOS
 
 ## [2.0.0]
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.0.1]
+
+### Changes
+
+- Now error codes for return values to CDV are parsed using the error enums and return proper strings instead of raw values
+
 ## [2.0.0]
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-unity-ads",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Cordova Unity Ads",
   "cordova": {
     "id": "cordova-plugin-unity-ads",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-unity-ads",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cordova Unity Ads",
   "cordova": {
     "id": "cordova-plugin-unity-ads",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-unity-ads" version="2.0.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-unity-ads" version="2.0.1">
     <name>Unity Ads</name>
     <description>Cordova Unity Ads</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-unity-ads" version="2.0.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-unity-ads" version="2.1.0">
     <name>Unity Ads</name>
     <description>Cordova Unity Ads</description>
     <license>Apache 2.0</license>

--- a/src/android/UnityAdsPlugin.java
+++ b/src/android/UnityAdsPlugin.java
@@ -24,6 +24,10 @@ public class UnityAdsPlugin extends CordovaPlugin {
 
     private AdsListener adsListener = new AdsListener();
 
+    public static String getErrorMessage(String message, String error) {
+        return String.format("[\"%s\",\"%s\"]", message, error);
+    }
+
     public static String[] getVideoAdsParameters(JSONArray args) {
         try {
             String serverId = args.getString(0);
@@ -77,7 +81,7 @@ public class UnityAdsPlugin extends CordovaPlugin {
             public void onUnityAdsShowFailure(String placementId, UnityAds.UnityAdsShowError error, String message) {
                 Log.d(TAG, String.format("videoAdPlacementId: %s %s", placementId, "onUnityAdsError"));
                 Log.d(TAG, String.format("%s", message));
-                callbackID.error(String.format("[\"%s\",\"%s\"]", message, error.name()));
+                callbackID.error(getErrorMessage(message, error.name()));
             }
 
             @Override
@@ -98,10 +102,10 @@ public class UnityAdsPlugin extends CordovaPlugin {
                     return;
                 }
                 if (UnityAds.UnityAdsShowCompletionState.SKIPPED.equals(state)) {
-                    callbackID.error("VIDEO_SKIPPED");
+                    callbackID.error(getErrorMessage("skipped", "SKIPPED"));
                     return;
                 }
-                callbackID.error("DID FINISH WITH ERROR");
+                callbackID.error(getErrorMessage("DID FINISH WITH ERROR", "ERROR"));
             }
         };
 
@@ -115,7 +119,7 @@ public class UnityAdsPlugin extends CordovaPlugin {
             public void onUnityAdsFailedToLoad(String placementId, UnityAds.UnityAdsLoadError error, String message) {
                 Log.d(TAG, String.format("videoAdPlacementId: %s %s", placementId, "onUnityAdsFailedToLoad"));
                 Log.d(TAG, String.format("%s", message));
-                callbackID.error(String.format("[\"%s\",\"%s\"]", message, error.name()));
+                callbackID.error(getErrorMessage(message, error.name()));
             }
         };
 
@@ -142,7 +146,7 @@ public class UnityAdsPlugin extends CordovaPlugin {
             try {
                 gameId = args.getString(0);
             } catch (JSONException e) {
-                callbackContext.error("Invalid Game ID");
+                callbackContext.error(getErrorMessage("Invalid Game ID", "INVALID_GAME_ID"));
                 return;
             }
 
@@ -159,7 +163,7 @@ public class UnityAdsPlugin extends CordovaPlugin {
             }
 
             if (INVALID_GAME_ID.equals(gameId)) {
-                callbackContext.error("Invalid Game ID");
+                callbackContext.error(getErrorMessage("Invalid Game ID", "INVALID_GAME_ID"));
                 return;
             }
 
@@ -175,7 +179,7 @@ public class UnityAdsPlugin extends CordovaPlugin {
         @Override
         public void onInitializationFailed(UnityAds.UnityAdsInitializationError error, String message) {
             Log.w(TAG, "onInitializationFailed" + message);
-            callbackID.error(String.format("[\"%s\",\"%s\"]", message, error.name()));
+            callbackID.error(getErrorMessage(message, error.name()));
         }
     }
 }

--- a/src/ios/UnityAdsPlugin.swift
+++ b/src/ios/UnityAdsPlugin.swift
@@ -87,7 +87,7 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
         case .showCompletionStateSkipped:
             result = constructPluginError(message: "skipped", error: "SKIPPED")
         @unknown default:
-            result = constructPluginError(message: "unknown", error: "unknown")
+            result = constructPluginError(message: "unknown", error: "UNKNOWN")
         }
         if let callbackId = self.currentCallbackId {
             self.commandDelegate.send(result, callbackId: callbackId)
@@ -198,7 +198,8 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
                return CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Error when parsing SDK failure\", \"JSON_PARSE_FAILED\"]")
             }
         } catch {
-            return CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Error when parsing SDK failure\", \"JSON_PARSE_FAILED\"]")        }
+            return CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Error when parsing SDK failure\", \"JSON_PARSE_FAILED\"]")        
+        }
     }
     
 }

--- a/src/ios/UnityAdsPlugin.swift
+++ b/src/ios/UnityAdsPlugin.swift
@@ -14,7 +14,7 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
             return
         }
         guard let gameId = command.argument(at: 0) as? String, !gameId.isEmpty else {
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Game ID missing")
+            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Game ID missing\", \"GAME_ID_MISSING\"]")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
             return
         }
@@ -28,17 +28,17 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
     @objc func show(_ command: CDVInvokedUrlCommand) {
         self.currentCallbackId = command.callbackId
         if !UnityAds.isInitialized() {
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Unity Ads not initialized")
+            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Unity Ads not initialized\", \"NOT_INITIALIZED\"]")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
             return
         }
         guard let serverId = command.argument(at: 0) as? String, !serverId.isEmpty else {
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Server ID missing")
+            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Server ID missing\", \"SERVER_ID_MISSING\"]")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
             return
         }
         guard let placementId = command.argument(at: 1) as? String, !placementId.isEmpty else {
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Placement ID missing")
+            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Placement ID missing\", \"PLACEMENT_ID_MISSING\"]")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
             return
         }
@@ -58,7 +58,8 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
     }
     
     func initializationFailed(_ error: UnityAdsInitializationError, withMessage message: String) {
-        let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "\(error): \(message)")
+        let errorString = initErrorToString(error)
+        let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"\(message)\", \"\(errorString)\"]")
         if let callbackId = self.currentCallbackId {
             self.commandDelegate.send(pluginResult, callbackId: callbackId)
         }
@@ -83,9 +84,9 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
         case .showCompletionStateCompleted:
             result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: "completed")
         case .showCompletionStateSkipped:
-            result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "skipped")
+            result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"skipped\", \"SKIPPED\"]")
         @unknown default:
-            result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "unknown")
+            result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"unknown\", \"UNKNOWN\"]")
         }
         if let callbackId = self.currentCallbackId {
             self.commandDelegate.send(result, callbackId: callbackId)
@@ -93,7 +94,8 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
     }
     
     func unityAdsShowFailed(_ placementId: String, withError error: UnityAdsShowError, withMessage message: String) {
-        let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "\(error): \(message)")
+        let errorString = showErrorToString(error)
+        let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"\(message)\", \"\(errorString)\"]")
         if let callbackId = self.currentCallbackId {
             self.commandDelegate.send(pluginResult, callbackId: callbackId)
         }
@@ -106,9 +108,63 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
     }
     
     func unityAdsAdFailed(toLoad placementId: String, withError error: UnityAdsLoadError, withMessage message: String) {
-        let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "\(error): \(message)")
+        let errorString = loadErrorToString(error)
+        let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"\(message)\", \"\(errorString)\"]")
         if let callbackId = self.currentCallbackId {
             self.commandDelegate.send(pluginResult, callbackId: callbackId)
+        }
+    }
+
+    private func loadErrorToString(_ error: UnityAdsLoadError) -> String {
+        switch error {
+            case .initializeFailed:
+                return "INITIALIZE_FAILED"
+            case .internal:
+                return "INTERNAL_ERROR"
+            case .invalidArgument:
+                return "INVALID_ARGUMENT"
+            case .noFill:
+                return "NO_FILL"
+            case .timeout:
+                return "TIMEOUT"
+            @unknown default:
+                return "UNKNOWN"
+        }
+    }
+    
+    private func showErrorToString(_ error: UnityAdsShowError) -> String {
+        switch error {
+            case .showErrorNotInitialized:
+                return "NOT_INITIALIZED"
+            case .showErrorNotReady:
+                return "NOT_READY"
+            case .showErrorVideoPlayerError:
+                return "VIDEO_PLAYER_ERROR"
+            case .showErrorInvalidArgument:
+                return "INVALID_ARGUMENT"
+            case .showErrorNoConnection:
+                return "NO_CONNECTION"
+            case .showErrorAlreadyShowing:
+                return "ALREADY_SHOWING"
+            case .showErrorInternalError:
+                return "INTERNAL_ERROR"
+            case .showErrorTimeout:
+                return "TIMEOUT"
+            @unknown default:
+                return "UNKNOWN"
+        }
+    }
+
+    private func initErrorToString(_ error: UnityAdsInitializationError) -> String {
+        switch error {
+            case .initializationErrorAdBlockerDetected:
+                return "AD_BLOCKER_DETECTED"
+            case .initializationErrorInternalError:
+                return "INTERNAL_ERROR"
+            case .initializationErrorInvalidArgument:
+                return "INVALID_ARGUMENT"
+            @unknown default:
+                return "UNKNOWN"
         }
     }
     

--- a/src/ios/UnityAdsPlugin.swift
+++ b/src/ios/UnityAdsPlugin.swift
@@ -6,6 +6,8 @@ import UnityAds
 class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDelegate, UnityAdsLoadDelegate {
     var currentCallbackId: String?
     
+    // MARK: - Cordova exposed methods
+    
     @objc func initialize(_ command: CDVInvokedUrlCommand) {
         self.currentCallbackId = command.callbackId
         if UnityAds.isInitialized() {
@@ -14,31 +16,31 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
             return
         }
         guard let gameId = command.argument(at: 0) as? String, !gameId.isEmpty else {
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Game ID missing\", \"GAME_ID_MISSING\"]")
+            let pluginResult = constructPluginError(message: "Game ID missing", error: "GAME_ID_MISSING")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
             return
         }
         let testMode = (command.argument(at: 1) as? Bool) ?? false
         let debugMode = (command.argument(at: 2) as? Bool) ?? false
-        UnityAds.setDebugMode(debugMode)
-        UnityAds.initialize(gameId, testMode: testMode, initializationDelegate: self)
+        UnityAds.setDebugMode(false)
+        UnityAds.initialize(gameId, testMode: false, initializationDelegate: self)
     }
     
     
     @objc func show(_ command: CDVInvokedUrlCommand) {
         self.currentCallbackId = command.callbackId
         if !UnityAds.isInitialized() {
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Unity Ads not initialized\", \"NOT_INITIALIZED\"]")
+            let pluginResult = constructPluginError(message: "Unity Ads not initialized", error: "NOT_INITIALIZED")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
             return
         }
         guard let serverId = command.argument(at: 0) as? String, !serverId.isEmpty else {
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Server ID missing\", \"SERVER_ID_MISSING\"]")
+            let pluginResult = constructPluginError(message: "Server ID missing", error: "SERVER_ID_MISSING")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
             return
         }
         guard let placementId = command.argument(at: 1) as? String, !placementId.isEmpty else {
-            let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Placement ID missing\", \"PLACEMENT_ID_MISSING\"]")
+            let pluginResult = constructPluginError(message: "Placement ID missing", error: "PLACEMENT_ID_MISSING")
             self.commandDelegate.send(pluginResult, callbackId: command.callbackId)
             return
         }
@@ -58,8 +60,7 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
     }
     
     func initializationFailed(_ error: UnityAdsInitializationError, withMessage message: String) {
-        let errorString = initErrorToString(error)
-        let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"\(message)\", \"\(errorString)\"]")
+        let pluginResult = constructPluginError(message: message, error: error)
         if let callbackId = self.currentCallbackId {
             self.commandDelegate.send(pluginResult, callbackId: callbackId)
         }
@@ -84,9 +85,9 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
         case .showCompletionStateCompleted:
             result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: "completed")
         case .showCompletionStateSkipped:
-            result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"skipped\", \"SKIPPED\"]")
+            result = constructPluginError(message: "skipped", error: "SKIPPED")
         @unknown default:
-            result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"unknown\", \"UNKNOWN\"]")
+            result = constructPluginError(message: "unknown", error: "unknown")
         }
         if let callbackId = self.currentCallbackId {
             self.commandDelegate.send(result, callbackId: callbackId)
@@ -94,8 +95,7 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
     }
     
     func unityAdsShowFailed(_ placementId: String, withError error: UnityAdsShowError, withMessage message: String) {
-        let errorString = showErrorToString(error)
-        let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"\(message)\", \"\(errorString)\"]")
+        let pluginResult = constructPluginError(message: message, error: error)
         if let callbackId = self.currentCallbackId {
             self.commandDelegate.send(pluginResult, callbackId: callbackId)
         }
@@ -108,12 +108,13 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
     }
     
     func unityAdsAdFailed(toLoad placementId: String, withError error: UnityAdsLoadError, withMessage message: String) {
-        let errorString = loadErrorToString(error)
-        let pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"\(message)\", \"\(errorString)\"]")
+        let pluginResult = constructPluginError(message: message, error: error)
         if let callbackId = self.currentCallbackId {
             self.commandDelegate.send(pluginResult, callbackId: callbackId)
         }
     }
+    
+    // MARK: - Error String switches
 
     private func loadErrorToString(_ error: UnityAdsLoadError) -> String {
         switch error {
@@ -166,6 +167,38 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
             @unknown default:
                 return "UNKNOWN"
         }
+    }
+    
+    // MARK: - Plugin Error Helpers
+
+    
+    private func constructPluginError(message: String, error: UnityAdsShowError) -> CDVPluginResult {
+        return constructPluginErrorResult(message: message, errorEnum: showErrorToString(error))
+    }
+    
+    private func constructPluginError(message: String, error: UnityAdsLoadError) -> CDVPluginResult {
+        return constructPluginErrorResult(message: message, errorEnum: loadErrorToString(error))
+    }
+    
+    private func constructPluginError(message: String, error: UnityAdsInitializationError) -> CDVPluginResult {
+        return constructPluginErrorResult(message: message, errorEnum: initErrorToString(error))
+    }
+    
+    private func constructPluginError(message: String, error: String) -> CDVPluginResult {
+        return constructPluginErrorResult(message: message, errorEnum: error)
+    }
+    
+    private func constructPluginErrorResult(message: String, errorEnum: String) -> CDVPluginResult {
+        do {
+            let messageStructure = [message, errorEnum]
+            let jsonData = try JSONSerialization.data(withJSONObject: messageStructure)
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                return CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: jsonString)
+            } else {
+               return CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Error when parsing SDK failure\", \"JSON_PARSE_FAILED\"]")
+            }
+        } catch {
+            return CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "[\"Error when parsing SDK failure\", \"JSON_PARSE_FAILED\"]")        }
     }
     
 }

--- a/src/ios/UnityAdsPlugin.swift
+++ b/src/ios/UnityAdsPlugin.swift
@@ -22,8 +22,8 @@ class UnityAdsPlugin: CDVPlugin, UnityAdsInitializationDelegate, UnityAdsShowDel
         }
         let testMode = (command.argument(at: 1) as? Bool) ?? false
         let debugMode = (command.argument(at: 2) as? Bool) ?? false
-        UnityAds.setDebugMode(false)
-        UnityAds.initialize(gameId, testMode: false, initializationDelegate: self)
+        UnityAds.setDebugMode(debugMode)
+        UnityAds.initialize(gameId, testMode: testMode, initializationDelegate: self)
     }
     
     


### PR DESCRIPTION
## Description

Previously our code returned the raw values of the NSEnum, which were parsed as `JSON_PARSE_FAILED` due to how they were constructed and the messages were not helpful at all as well, something like `UnityAdsShowError(rawValue: 6)`

This aims to solve the error enum parsing so it shows a proper message, as well as bringing closer together the error messages of Android & iOS for better consistency when checking errors and handling them.