### PR TITLE
Update `UnityAds` to `4.19.0` align plugin version with `UnityAds` version

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,11 @@
 # Change Log
 
+## [4.19.0]
+
+### Changes
+- Updated Unity Ads SDK to 4.19.0
+- Aligned Plugin version with Unity Ads SDK version (for easier comparison and tracking of changes)
+
 ## [2.1.0]
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ UnityAds.show(serverId?: string, videoAdPlacementId?: string): Promise
 ## How to update the SDK
 
 - Make sure to check the [Changelog](https://docs.unity.com/en-us/grow/ads/changelog) from Unity
+- Always match the `UnityAds` version when bumping the plugin versions
+- Bump the `package.json` version
 - Bump the SDK version in the `plugin.xml` file
   - For `Android` in the `UNITY_ADS_VERSION` preference
   - For `iOS` in the podspec definition `<pod name="UnityAds" spec="X.Y.Z" />` where `X.Y.Z` is the exact version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-unity-ads",
-  "version": "2.1.0",
+  "version": "4.19.0",
   "description": "Cordova Unity Ads",
   "cordova": {
     "id": "cordova-plugin-unity-ads",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-unity-ads" version="2.1.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-unity-ads" version="4.19.0">
     <name>Unity Ads</name>
     <description>Cordova Unity Ads</description>
     <license>Apache 2.0</license>
@@ -16,7 +16,7 @@
                 <param name="onload" value="true" />
             </feature>
         </config-file>
-        <preference name="UNITY_ADS_VERSION" default="4.16.3" />
+        <preference name="UNITY_ADS_VERSION" default="4.19.0" />
 
 
         <framework src="src/android/UnityAdsPlugin.gradle" custom="true" type="gradleReference" />
@@ -38,7 +38,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="UnityAds" spec="4.16.3" />
+                <pod name="UnityAds" spec="4.19.0" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
See Unity CHANGELOG https://docs.unity.com/en-us/grow/ads/changelog

There are some methods that are deprecated in this current release, but are still working, a followup is necessary to update the code to remove this deprecated code, but this is outside the scope of this task.

The Plugin version is now also aligned with the UnityAds dependency used in both platforms.